### PR TITLE
feat: add puskesmas

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
 				"@types/cookie": "^0.4.0",
 				"@typescript-eslint/eslint-plugin": "^4.19.0",
 				"@typescript-eslint/parser": "^4.19.0",
+				"airtable": "^0.11.1",
 				"autoprefixer": "^10.2.6",
 				"cssnano": "^5.0.6",
 				"eslint": "^7.22.0",
@@ -519,6 +520,24 @@
 				}
 			}
 		},
+		"node_modules/abort-controller": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+			"integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+			"dev": true,
+			"dependencies": {
+				"event-target-shim": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=6.5"
+			}
+		},
+		"node_modules/abortcontroller-polyfill": {
+			"version": "1.7.3",
+			"resolved": "https://registry.npmjs.org/abortcontroller-polyfill/-/abortcontroller-polyfill-1.7.3.tgz",
+			"integrity": "sha512-zetDJxd89y3X99Kvo4qFx8GKlt6GsvN3UcRZHwU6iFA/0KiOmhkTVhe8oRoTBiTVPZu09x3vCra47+w8Yz1+2Q==",
+			"dev": true
+		},
 		"node_modules/acorn": {
 			"version": "7.4.1",
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
@@ -559,6 +578,28 @@
 			"engines": {
 				"node": ">=0.4.0"
 			}
+		},
+		"node_modules/airtable": {
+			"version": "0.11.1",
+			"resolved": "https://registry.npmjs.org/airtable/-/airtable-0.11.1.tgz",
+			"integrity": "sha512-33zBuUDhLl+FWWAFxFjS1a+vJr/b+UK//EV943nuiimChWph6YykQjYPmu/GucQ30g7mgaqq+98uPD4rfDHOgg==",
+			"dev": true,
+			"dependencies": {
+				"@types/node": ">=8.0.0 <15",
+				"abort-controller": "^3.0.0",
+				"abortcontroller-polyfill": "^1.4.0",
+				"lodash": "^4.17.21",
+				"node-fetch": "^2.6.1"
+			},
+			"engines": {
+				"node": ">=8.0.0"
+			}
+		},
+		"node_modules/airtable/node_modules/@types/node": {
+			"version": "14.17.5",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.5.tgz",
+			"integrity": "sha512-bjqH2cX/O33jXT/UmReo2pM7DIJREPMnarixbQ57DOOzzFaI6D2+IcwaJQaJpv0M1E9TIhPCYVxrkcityLjlqA==",
+			"dev": true
 		},
 		"node_modules/ajv": {
 			"version": "6.12.6",
@@ -1632,6 +1673,15 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/event-target-shim": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+			"integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=6"
+			}
+		},
 		"node_modules/fast-deep-equal": {
 			"version": "3.1.3",
 			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -2347,6 +2397,15 @@
 			"dev": true,
 			"dependencies": {
 				"lodash.toarray": "^4.4.0"
+			}
+		},
+		"node_modules/node-fetch": {
+			"version": "2.6.1",
+			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+			"integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
+			"dev": true,
+			"engines": {
+				"node": "4.x || >=6.0.0"
 			}
 		},
 		"node_modules/node-releases": {
@@ -4371,6 +4430,21 @@
 			"integrity": "sha512-m4rM5W9LlZjj8t3YqI9biWd6wPkDe/i2imYy0+NoJBIovQ7rpWFyG73UtR/DbIuuxIDQLzPSPPEUdwhng2qiTw==",
 			"requires": {}
 		},
+		"abort-controller": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+			"integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+			"dev": true,
+			"requires": {
+				"event-target-shim": "^5.0.0"
+			}
+		},
+		"abortcontroller-polyfill": {
+			"version": "1.7.3",
+			"resolved": "https://registry.npmjs.org/abortcontroller-polyfill/-/abortcontroller-polyfill-1.7.3.tgz",
+			"integrity": "sha512-zetDJxd89y3X99Kvo4qFx8GKlt6GsvN3UcRZHwU6iFA/0KiOmhkTVhe8oRoTBiTVPZu09x3vCra47+w8Yz1+2Q==",
+			"dev": true
+		},
 		"acorn": {
 			"version": "7.4.1",
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
@@ -4400,6 +4474,27 @@
 			"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-7.2.0.tgz",
 			"integrity": "sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==",
 			"dev": true
+		},
+		"airtable": {
+			"version": "0.11.1",
+			"resolved": "https://registry.npmjs.org/airtable/-/airtable-0.11.1.tgz",
+			"integrity": "sha512-33zBuUDhLl+FWWAFxFjS1a+vJr/b+UK//EV943nuiimChWph6YykQjYPmu/GucQ30g7mgaqq+98uPD4rfDHOgg==",
+			"dev": true,
+			"requires": {
+				"@types/node": ">=8.0.0 <15",
+				"abort-controller": "^3.0.0",
+				"abortcontroller-polyfill": "^1.4.0",
+				"lodash": "^4.17.21",
+				"node-fetch": "^2.6.1"
+			},
+			"dependencies": {
+				"@types/node": {
+					"version": "14.17.5",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.5.tgz",
+					"integrity": "sha512-bjqH2cX/O33jXT/UmReo2pM7DIJREPMnarixbQ57DOOzzFaI6D2+IcwaJQaJpv0M1E9TIhPCYVxrkcityLjlqA==",
+					"dev": true
+				}
+			}
 		},
 		"ajv": {
 			"version": "6.12.6",
@@ -5200,6 +5295,12 @@
 			"integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
 			"dev": true
 		},
+		"event-target-shim": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+			"integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+			"dev": true
+		},
 		"fast-deep-equal": {
 			"version": "3.1.3",
 			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -5774,6 +5875,12 @@
 			"requires": {
 				"lodash.toarray": "^4.4.0"
 			}
+		},
+		"node-fetch": {
+			"version": "2.6.1",
+			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+			"integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
+			"dev": true
 		},
 		"node-releases": {
 			"version": "1.1.73",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
 		"@types/cookie": "^0.4.0",
 		"@typescript-eslint/eslint-plugin": "^4.19.0",
 		"@typescript-eslint/parser": "^4.19.0",
+		"airtable": "^0.11.1",
 		"autoprefixer": "^10.2.6",
 		"cssnano": "^5.0.6",
 		"eslint": "^7.22.0",

--- a/src/app.css
+++ b/src/app.css
@@ -52,6 +52,10 @@
 		@apply text-gray-600 border-gray-200;
 	}
 
+	.cv-mini-btn {
+		@apply py-0.5 px-2 text-center text-indigo-700 border border-indigo-700 hover:bg-indigo-700 focus:bg-indigo-700 hover:text-white focus:text-white rounded text-xs font-medium;
+	}
+
 	.cv-inline-link {
 		@apply border-b font-medium text-indigo-600 border-gray-400 hover:border-indigo-600 focus:border-indigo-600;
 	}

--- a/src/app.css
+++ b/src/app.css
@@ -63,4 +63,16 @@
 	.cv-misc-page__title {
 		@apply font-semibold text-3xl sm:text-4xl leading-tight mb-8 sm:mt-2;
 	}
+
+	.cv-loc-page__title {
+		@apply font-semibold text-2xl sm:text-3xl leading-tight mb-4;
+	}
+	.cv-loc-page__list-container {
+		@apply grid gap-3 text-sm;
+	}
+
+	.cv-list-no-cta {
+		@apply grid gap-x-2 gap-y-3;
+		grid-template-columns: 1rem 1fr;
+	}
 }

--- a/src/components/ListItemWithCta.svelte
+++ b/src/components/ListItemWithCta.svelte
@@ -1,0 +1,34 @@
+<script lang="ts">
+	export let text: string;
+	export let cta: {
+		href: string;
+		text: string;
+	};
+</script>
+
+<section class="list-item text-sm" {...$$restProps}>
+	<slot name="icon" />
+	<div>{text}</div>
+	<a class="list-item__cta cv-mini-btn" rel="external" href={cta.href}>{cta.text}</a>
+</section>
+
+<style lang="postcss">
+	.list-item {
+		@apply grid gap-x-2 gap-y-2 text-sm relative items-start;
+		grid-template-columns: 1rem 1fr auto;
+	}
+	.list-item > *:nth-child(3) {
+		margin-left: 0.25rem;
+	}
+	.list-item__cta {
+		@apply -mt-px w-16;
+	}
+	.list-item__cta::after {
+		content: "";
+		position: absolute;
+		top: 0;
+		bottom: 0;
+		left: 0;
+		right: 0;
+	}
+</style>

--- a/src/components/LocDetailSection.svelte
+++ b/src/components/LocDetailSection.svelte
@@ -1,0 +1,22 @@
+<script lang="ts">
+	import slugify from "slugify";
+	import { SLUGIFY_OPTIONS } from "$lib/constants";
+
+	export let title: string;
+
+	const ariaLabelName = slugify(title, SLUGIFY_OPTIONS);
+</script>
+
+<section class="loc-detail-section" aria-labelledby={ariaLabelName}>
+	<h2 class="loc-detail-section__h" id={ariaLabelName}>{title}</h2>
+	<slot />
+</section>
+
+<style lang="postcss">
+	.loc-detail-section {
+		@apply py-4 border-b;
+	}
+	.loc-detail-section__h {
+		@apply font-semibold sm:text-lg mb-2;
+	}
+</style>

--- a/src/components/LocationList.svelte
+++ b/src/components/LocationList.svelte
@@ -5,6 +5,11 @@
 
 	export let locations: ILocationInList[] = [];
 
+	const makeSlug = (name: string, type: string = null) => {
+		const path = type && type.toLowerCase() == "puskesmas" ? "p" : "di";
+		return `/${path}/${slugify(name, SLUGIFY_OPTIONS)}`;
+	};
+
 	// $: console.log("loc length?", locations);
 </script>
 
@@ -16,7 +21,7 @@
 		<a
 			id={`alabel-${loc.id}`}
 			class={`location__name ${loc.type ? `location__name--${loc.type.toLowerCase()}` : ""}`}
-			href={`/di/${slugify(loc.name, SLUGIFY_OPTIONS)}`}
+			href={makeSlug(loc.name, loc.type)}
 			sveltekit:prefetch
 		>
 			{`${loc.name} ${loc.canRegister ? "" : " ⛔️"}`}

--- a/src/components/LocationList.svelte
+++ b/src/components/LocationList.svelte
@@ -15,7 +15,7 @@
 	>
 		<a
 			id={`alabel-${loc.id}`}
-			class="location__name"
+			class={`location__name ${loc.type ? `location__name--${loc.type.toLowerCase()}` : ""}`}
 			href={`/di/${slugify(loc.name, SLUGIFY_OPTIONS)}`}
 			sveltekit:prefetch
 		>
@@ -49,6 +49,10 @@
 		bottom: 0;
 		left: 0;
 		right: 0;
+	}
+	.location__name--puskesmas::before {
+		content: "📁";
+		margin-right: 0.5em;
 	}
 	.location__desc {
 		@apply text-sm text-gray-600;

--- a/src/components/PuskesmasList.svelte
+++ b/src/components/PuskesmasList.svelte
@@ -1,0 +1,35 @@
+<script>
+	export let clinics = [
+		{ name: "PUSKESMAS DANUREJAN I", address: "Jl. Bausasran, Kec. Danurejan" },
+		{ name: "PUSKESMAS DANUREJAN II", address: "Jl. Krasak Timur 34, Kec. Danurejan" },
+		{ name: "PUSKESMAS GEDONG TENGEN", address: "Jl. Pringgokusuman 30, Kec. Gedong Tengen" },
+		{ name: "PUSKESMAS GONDO KUSUMAN I", address: "Jl. Tunjung Baciro, Kec. Gondokusuman" },
+		{
+			name: "PUSKESMAS GONDO KUSUMAN II",
+			address: "Jl. Prof.Dr.Sardjito No.22, Kec. Gondokusuman",
+		},
+		{ name: "PUSKESMAS GONDOMANAN", address: "Jl. Gondomanan No.9, Kec. Gondomanan" },
+		{ name: "PUSKESMAS JETIS", address: "Jl. Diponegoro 91, Kec. Jetis" },
+		{ name: "PUSKESMAS KOTA GEDE I", address: "Jl. Kemasan 12, Kec. Kotagede" },
+		{ name: "PUSKESMAS KOTA GEDE II", address: "Jl. Ki Penjawi 4, Kec. Kotagede" },
+	];
+</script>
+
+<section class="p-4">
+	<h2 class="font-semibold sm:text-lg mt-2 mb-6">Daftar Puskesmas</h2>
+
+	<div class="grid gap-y-6 gap-x-11 sm:grid-cols-2 md:grid-cols-3">
+		{#each clinics as clinic}
+			<article class="pt-3 border-t-2 border-indigo-400">
+				<strong class="font-medium text-sm leading-tight inline-block">{clinic.name}</strong>
+				<p class="text-gray-600 text-xs mt-1 mb-2">📍&nbsp; {clinic?.address}</p>
+				<a
+					class="-mt-px py-0.5 px-2 text-center text-indigo-700 border border-indigo-700 hover:bg-indigo-700 focus:bg-indigo-700 hover:text-white focus:text-white rounded text-xs font-medium"
+					href={`https://www.google.com/maps/search/${clinic.name}`}>Maps</a
+				>
+			</article>
+		{:else}
+			<p>Data puskesmas tidak ditemukan</p>
+		{/each}
+	</div>
+</section>

--- a/src/components/PuskesmasList.svelte
+++ b/src/components/PuskesmasList.svelte
@@ -1,5 +1,5 @@
-<script>
-	export let clinics = [
+<script lang="ts">
+	export let clinics: IClinic[] = [
 		{ name: "PUSKESMAS DANUREJAN I", address: "Jl. Bausasran, Kec. Danurejan" },
 		{ name: "PUSKESMAS DANUREJAN II", address: "Jl. Krasak Timur 34, Kec. Danurejan" },
 		{ name: "PUSKESMAS GEDONG TENGEN", address: "Jl. Pringgokusuman 30, Kec. Gedong Tengen" },
@@ -17,19 +17,20 @@
 
 <section class="p-4">
 	<h2 class="font-semibold sm:text-lg mt-2 mb-6">Daftar Puskesmas</h2>
-
 	<div class="grid gap-y-6 gap-x-11 sm:grid-cols-2 md:grid-cols-3">
 		{#each clinics as clinic}
 			<article class="pt-3 border-t-2 border-indigo-400">
 				<strong class="font-medium text-sm leading-tight inline-block">{clinic.name}</strong>
-				<p class="text-gray-600 text-xs mt-1 mb-2">📍&nbsp; {clinic?.address}</p>
-				<a
-					class="-mt-px py-0.5 px-2 text-center text-indigo-700 border border-indigo-700 hover:bg-indigo-700 focus:bg-indigo-700 hover:text-white focus:text-white rounded text-xs font-medium"
-					href={`https://www.google.com/maps/search/${clinic.name}`}>Maps</a
-				>
+				<p class="text-gray-600 text-xs mt-1 mb-2">
+					<span aria-hidden="true">📍&nbsp;</span>
+					{clinic?.address}
+				</p>
+				<a class="cv-mini-btn" href={`https://www.google.com/maps/search/${clinic.name}`}> Maps </a>
 			</article>
 		{:else}
-			<p>Data puskesmas tidak ditemukan</p>
+			<p class="col-span-full text-gray-700 text-center text-sm p-4">
+				Data puskesmas tidak ditemukan
+			</p>
 		{/each}
 	</div>
 </section>

--- a/src/components/PuskesmasList.svelte
+++ b/src/components/PuskesmasList.svelte
@@ -1,36 +1,25 @@
 <script lang="ts">
-	export let clinics: IClinic[] = [
-		{ name: "PUSKESMAS DANUREJAN I", address: "Jl. Bausasran, Kec. Danurejan" },
-		{ name: "PUSKESMAS DANUREJAN II", address: "Jl. Krasak Timur 34, Kec. Danurejan" },
-		{ name: "PUSKESMAS GEDONG TENGEN", address: "Jl. Pringgokusuman 30, Kec. Gedong Tengen" },
-		{ name: "PUSKESMAS GONDO KUSUMAN I", address: "Jl. Tunjung Baciro, Kec. Gondokusuman" },
-		{
-			name: "PUSKESMAS GONDO KUSUMAN II",
-			address: "Jl. Prof.Dr.Sardjito No.22, Kec. Gondokusuman",
-		},
-		{ name: "PUSKESMAS GONDOMANAN", address: "Jl. Gondomanan No.9, Kec. Gondomanan" },
-		{ name: "PUSKESMAS JETIS", address: "Jl. Diponegoro 91, Kec. Jetis" },
-		{ name: "PUSKESMAS KOTA GEDE I", address: "Jl. Kemasan 12, Kec. Kotagede" },
-		{ name: "PUSKESMAS KOTA GEDE II", address: "Jl. Ki Penjawi 4, Kec. Kotagede" },
-	];
+	export let clinics: IClinic[] = [];
+
+	const makeMapUrl = (name: string) => {
+		const baseUrl = `https://www.google.com/maps/search`;
+		return name.startsWith("Puskesmas") ? `${baseUrl}/${name}` : `${baseUrl}/Puskesmas ${name}`;
+	};
 </script>
 
-<section class="p-4">
-	<h2 class="font-semibold sm:text-lg mt-2 mb-6">Daftar Puskesmas</h2>
-	<div class="grid gap-y-6 gap-x-11 sm:grid-cols-2 md:grid-cols-3">
-		{#each clinics as clinic}
-			<article class="pt-3 border-t-2 border-indigo-400">
-				<strong class="font-medium text-sm leading-tight inline-block">{clinic.name}</strong>
-				<p class="text-gray-600 text-xs mt-1 mb-2">
-					<span aria-hidden="true">📍&nbsp;</span>
-					{clinic?.address}
-				</p>
-				<a class="cv-mini-btn" href={`https://www.google.com/maps/search/${clinic.name}`}> Maps </a>
-			</article>
-		{:else}
-			<p class="col-span-full text-gray-700 text-center text-sm p-4">
-				Data puskesmas tidak ditemukan
+<div class="grid gap-y-6 gap-x-11 sm:grid-cols-2 md:grid-cols-3 pb-2">
+	{#each clinics as clinic}
+		<article class="pt-3 border-t-2 border-indigo-400">
+			<strong class="font-medium text-sm leading-tight inline-block">{clinic.name}</strong>
+			<p class="text-xs text-gray-700 mt-1 mb-2">
+				<span aria-hidden="true">📍&nbsp;</span>
+				{clinic?.address}
 			</p>
-		{/each}
-	</div>
-</section>
+			<a class="cv-mini-btn" href={makeMapUrl(clinic.name)}>Maps</a>
+		</article>
+	{:else}
+		<p class="col-span-full text-gray-700 text-center text-sm p-4">
+			Data puskesmas tidak ditemukan
+		</p>
+	{/each}
+</div>

--- a/src/components/RegistrationList.svelte
+++ b/src/components/RegistrationList.svelte
@@ -1,0 +1,63 @@
+<script lang="ts">
+	import ListItemWithCta from "./ListItemWithCta.svelte";
+
+	export let registrations: ILocationFull["registrations"];
+	export let registerLinks: ILocationFull["registerLinks"];
+	export let registerNote: ILocationFull["registerNote"];
+</script>
+
+{#if registrations.includes("Daftar di lokasi")}
+	<p>{registrations.join(", ")}</p>
+{/if}
+{#if registerLinks.app}
+	<section class="cv-list-no-cta" aria-label="aplikasi">
+		<span>📱</span>
+		<p>
+			Daftar melalui aplikasi. Unduh di
+			{#each registerLinks.app as appLink, i}
+				<a class="cv-inline-link" href={appLink.url}>{appLink.text}</a>
+				{#if i < 1 && registerLinks.app.length > 1}&nbsp;/&nbsp;{/if}
+			{/each}
+		</p>
+	</section>
+{/if}
+{#if registerLinks.form}
+	<ListItemWithCta
+		aria-label="formulir"
+		text={registerLinks.form.replace("https://", "").replace("http://", "")}
+		cta={{ href: registerLinks.form, text: "Buka" }}
+	>
+		<span slot="icon">📱</span>
+	</ListItemWithCta>
+{/if}
+{#if registerLinks.phone}
+	<ListItemWithCta
+		aria-label="telepon"
+		text={registerLinks.phone.text}
+		cta={{ href: registerLinks.phone.url, text: "Panggil" }}
+	>
+		<span slot="icon">📞</span>
+	</ListItemWithCta>
+{/if}
+{#if registerLinks.whatsapp}
+	<ListItemWithCta
+		aria-label="WhatsApp"
+		text={registerLinks.whatsapp.text}
+		cta={{ href: registerLinks.whatsapp.url, text: "Chat" }}
+	>
+		<!-- prettier-ignore -->
+		<svg slot="icon" class="mt-0.5" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 58 58">
+			<path style="fill:#2CB742;" d="M0,58l4.988-14.963C2.457,38.78,1,33.812,1,28.5C1,12.76,13.76,0,29.5,0S58,12.76,58,28.5 S45.24,57,29.5,57c-4.789,0-9.299-1.187-13.26-3.273L0,58z"/>
+			<path style="fill:#FFFFFF;" d="M47.683,37.985c-1.316-2.487-6.169-5.331-6.169-5.331c-1.098-0.626-2.423-0.696-3.049,0.42
+				c0,0-1.577,1.891-1.978,2.163c-1.832,1.241-3.529,1.193-5.242-0.52l-3.981-3.981l-3.981-3.981c-1.713-1.713-1.761-3.41-0.52-5.242
+				c0.272-0.401,2.163-1.978,2.163-1.978c1.116-0.627,1.046-1.951,0.42-3.049c0,0-2.844-4.853-5.331-6.169
+				c-1.058-0.56-2.357-0.364-3.203,0.482l-1.758,1.758c-5.577,5.577-2.831,11.873,2.746,17.45l5.097,5.097l5.097,5.097
+				c5.577,5.577,11.873,8.323,17.45,2.746l1.758-1.758C48.048,40.341,48.243,39.042,47.683,37.985z"/>
+		</svg>
+	</ListItemWithCta>
+{/if}
+{#if registerNote}
+	<div class="text-xs text-gray-700 leading-normal whitespace-pre-line max-w-xl my-1">
+		{registerNote}
+	</div>
+{/if}

--- a/src/components/RequirementList.svelte
+++ b/src/components/RequirementList.svelte
@@ -1,0 +1,37 @@
+<script lang="ts">
+	export let data: ILocationFull["requirementDetails"];
+</script>
+
+{#if data.ktp}
+	<p class="requirement-item" aria-labelledby="alabel-domisili">
+		<strong id="alabel-domisili" class="requirement-item__title">Domisili</strong>
+		<span>{data.ktp}</span>
+	</p>
+{/if}
+{#if data.work}
+	<p class="requirement-item" aria-labelledby="alabel-kerja">
+		<strong id="alabel-kerja" class="requirement-item__title">Pekerjaan/Usaha</strong>
+		<span>{data.work}</span>
+	</p>
+{/if}
+{#if data.note}
+	<p class="requirement-item">
+		<strong class="requirement-item__title hide-if-only">Lainnya</strong>
+		<span>{data.note}</span>
+	</p>
+{/if}
+
+<style lang="postcss">
+	.requirement-item {
+		@apply whitespace-pre-line;
+	}
+	.requirement-item__title {
+		@apply text-indigo-600 font-semibold;
+	}
+	.requirement-item__title::after {
+		content: " · ";
+	}
+	.requirement-item:only-child .requirement-item__title.hide-if-only {
+		@apply sr-only;
+	}
+</style>

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -1,4 +1,6 @@
+export { default as EmbedInstagram } from "./EmbedInstagram.svelte";
 export { default as Header } from "./Header.svelte";
 export { default as Footer } from "./Footer.svelte";
 export { default as LocationList } from "./LocationList.svelte";
+export { default as PuskesmasList } from "./PuskesmasList.svelte";
 export { default as TagList } from "./TagList.svelte";

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -1,6 +1,10 @@
 export { default as EmbedInstagram } from "./EmbedInstagram.svelte";
 export { default as Header } from "./Header.svelte";
 export { default as Footer } from "./Footer.svelte";
+export { default as ListItemWithCta } from "./ListItemWithCta.svelte";
 export { default as LocationList } from "./LocationList.svelte";
+export { default as LocDetailSection } from "./LocDetailSection.svelte";
 export { default as PuskesmasList } from "./PuskesmasList.svelte";
+export { default as RequirementList } from "./RequirementList.svelte";
+export { default as RegistrationList } from "./RegistrationList.svelte";
 export { default as TagList } from "./TagList.svelte";

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -112,6 +112,11 @@ type PropsInList = | "id" | "name" | "city" | "phone" | "ageGroups" | "requireme
 
 type ILocationInList = Pick<ILocationFull, PropsInList>;
 
+interface IClinic {
+	name: string;
+	address: string;
+}
+
 // = = = =
 // = = = =
 

--- a/src/lib/build-airtable-url.ts
+++ b/src/lib/build-airtable-url.ts
@@ -1,0 +1,7 @@
+/* eslint-disable @typescript-eslint/explicit-module-boundary-types */
+export const AIRTABLE_API_HOST = `https://api.airtable.com/v0/`;
+
+export const makeFieldsParam = (fields: string[]) =>
+	fields.map((item) => `fields${encodeURIComponent("[]")}=${item}`).join("&");
+
+export const makeFilterParam = (str: string) => `filterByFormula=${encodeURIComponent(str)}`;

--- a/src/lib/stores/user-settings.ts
+++ b/src/lib/stores/user-settings.ts
@@ -2,7 +2,7 @@ import { writable } from "svelte/store";
 import { browser } from "$app/env";
 
 // Customize fallback initial data if no localStorage data.
-const DEFAULT_USER_SETTINGS = { offlineNoticeDismissed: false };
+const DEFAULT_USER_SETTINGS = { offlineNoticeDismissed: false, hasPrefetched: false };
 
 // Get the value out of storage on load.
 let initialData: IUserSettings = DEFAULT_USER_SETTINGS;

--- a/src/lib/transform-pipedream-data.ts
+++ b/src/lib/transform-pipedream-data.ts
@@ -44,6 +44,7 @@ export const transformLocationData = (items: IAirtableLocation[]): ILocationInLi
 			gmapUrl: item.gmap_url || undefined,
 			phone,
 			address,
+			type: item.location_type ? item.location_type[0] : undefined,
 			canRegister: !!(!item.date_close || new Date() <= new Date(item.date_close)),
 			registrations: item.register_how_to || [],
 			registerNote: item.register_note || undefined,

--- a/src/routes/api/pd_clinics.ts
+++ b/src/routes/api/pd_clinics.ts
@@ -1,0 +1,43 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable @typescript-eslint/ban-ts-comment */
+import type { RequestHandler } from "@sveltejs/kit";
+import dotenv from "dotenv";
+import { AIRTABLE_API_HOST, makeFieldsParam, makeFilterParam } from "$lib/build-airtable-url";
+
+dotenv.config();
+
+const { AIRTABLE_API_KEY, AIRTABLE_BASE_ID } = process.env; // must be destructured, else stripped by Vite
+
+const apiUrl = `${AIRTABLE_API_HOST}${AIRTABLE_BASE_ID}/puskesmas`;
+const queryFields = ["name", "address"];
+
+// = = = = = = = =
+// = = = = = = = =
+
+export const get: RequestHandler = async ({ query }) => {
+	const city = query.get("city");
+
+	const url = city
+		? `${apiUrl}?${makeFieldsParam(queryFields)}&${makeFilterParam(`city="${city}"`)}`
+		: apiUrl;
+
+	return fetch(url, {
+		headers: { Authorization: `Bearer ${AIRTABLE_API_KEY}` },
+	})
+		.then((res) => res.json())
+		.then((data) => {
+			const clinics: IClinic[] =
+				data.records?.map((item) => ({
+					id: item.id,
+					...item.fields,
+				})) || [];
+			return {
+				body: { payload: clinics },
+			};
+		})
+		.catch((err) => {
+			console.log(err);
+			return { status: err.status };
+		});
+	// return { status: 200, body: { payload: [{ name: "foo", address: "bar" }] } }; // leave for checking
+};

--- a/src/routes/api/pd_location_[slug].ts
+++ b/src/routes/api/pd_location_[slug].ts
@@ -17,7 +17,6 @@ export const get: RequestHandler = async ({ params }) => {
 		const readRes = await res.json();
 		if (readRes.payload)
 			return {
-				status: 200,
 				body: {
 					payload: transformLocationData(readRes.payload)[0],
 				},

--- a/src/routes/api/pd_locations.ts
+++ b/src/routes/api/pd_locations.ts
@@ -21,11 +21,12 @@ interface IMyOutput {
 }
 
 export const get = async (): Promise<IMyOutput> => {
-	// if (dev)
-	// 	return {
-	// 		status: 200,
-	// 		body: { payload: [] },
-	// 	};
+	// FIXME ntar balikin
+	if (dev)
+		return {
+			status: 200,
+			body: { payload: [] },
+		};
 
 	const res = await fetch(PIPEDREAM_API_URL);
 	if (res.ok) {

--- a/src/routes/api/pd_locations.ts
+++ b/src/routes/api/pd_locations.ts
@@ -2,8 +2,8 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 // import type { RequestHandler, EndpointOutput } from "@sveltejs/kit";
 import dotenv from "dotenv";
-import { dev } from "$app/env";
 import { transformLocationData } from "$lib/transform-pipedream-data";
+// import { dev } from "$app/env";
 
 dotenv.config();
 
@@ -21,18 +21,15 @@ interface IMyOutput {
 }
 
 export const get = async (): Promise<IMyOutput> => {
-	// FIXME ntar balikin
-	if (dev)
-		return {
-			status: 200,
-			body: { payload: [] },
-		};
+	// if (dev)
+	// 	return {
+	// 		body: { payload: [] },
+	// 	};
 
 	const res = await fetch(PIPEDREAM_API_URL);
 	if (res.ok) {
 		const readRes = await res.json();
 		return {
-			status: 200,
 			body: {
 				payload: transformLocationData(readRes.payload),
 			},

--- a/src/routes/di/[slug].svelte
+++ b/src/routes/di/[slug].svelte
@@ -25,8 +25,7 @@
 
 <script lang="ts">
 	import { onMount } from "svelte";
-	import { TagList } from "../../components";
-	import EmbedInstagram from "../../components/EmbedInstagram.svelte";
+	import { TagList, EmbedInstagram, PuskesmasList } from "../../components";
 	import { PROVINCE_NAME, HEADING_TEXT } from "$lib/constants";
 
 	export let location: ILocationFull;
@@ -140,13 +139,12 @@
 											c5.577,5.577,11.873,8.323,17.45,2.746l1.758-1.758C48.048,40.341,48.243,39.042,47.683,37.985z"/>
 									</svg>
 								</span>
-								<!-- <span>{`WA ${location.registerLinks.whatsapp.text}`}</span> -->
 								<span>{location.registerLinks.whatsapp.text}</span>
 								<a class="list__item-cta" href={location.registerLinks.whatsapp.url}>Kirim</a>
 							</section>
 						{/if}
 						{#if location.registerNote}
-							<div class="text-gray-700 text-xs whitespace-pre-line mt-1">
+							<div class="text-gray-700 text-xs whitespace-pre-line max-w-xl mt-1">
 								{location.registerNote}
 							</div>
 						{/if}
@@ -228,6 +226,10 @@
 						</div>
 					{/if}
 				</section>
+			{/if}
+
+			{#if location.type && location.type == "Puskesmas"}
+				<PuskesmasList />
 			{/if}
 		</div>
 	{:else}

--- a/src/routes/di/[slug].svelte
+++ b/src/routes/di/[slug].svelte
@@ -25,7 +25,14 @@
 
 <script lang="ts">
 	import { onMount } from "svelte";
-	import { TagList, EmbedInstagram, PuskesmasList } from "../../components";
+	import {
+		EmbedInstagram,
+		ListItemWithCta,
+		LocDetailSection,
+		RegistrationList,
+		RequirementList,
+		TagList,
+	} from "../../components";
 	import { PROVINCE_NAME, HEADING_TEXT } from "$lib/constants";
 
 	export let location: ILocationFull;
@@ -49,189 +56,116 @@
 
 <main class="cv-page-outer">
 	{#if location}
-		<h1 class="font-semibold text-2xl sm:text-3xl leading-tight mb-4">
+		<h1 class="cv-loc-page__title">
 			{`${location.name} ${location.canRegister ? "" : " ⛔️"}`}
 		</h1>
-		<div>
+		<div class="mb-2" aria-label="kelompok usia">
 			<TagList requirements={location.requirementsByAgeGroup} />
 		</div>
 
 		{#if !location.canRegister}
 			<div
-				class="relative px-4 py-3 mt-4 text-red-700 bg-red-50 rounded text-sm border-l-4 border-red-500"
+				class="relative px-4 py-3 mt-6 mb-2 text-red-700 bg-red-50 rounded text-sm border-l-4 border-red-500"
 				role="alert"
 			>
 				<p class="ml-1">⚠️&nbsp; {location.registerNote || "Pendaftaran ditutup"}</p>
 			</div>
 		{/if}
 
-		<div class="my-2 -mx-4">
-			{#if location.canRegister && Object.keys(location.requirementDetails).length}
-				<section class="top-section" aria-labelledby="alabel-syarat">
-					<h2 id="alabel-syarat">Syarat</h2>
-					<div class="grid gap-3 text-sm">
-						{#if location.requirementDetails.ktp}
-							<p class="requirement-item" aria-labelledby="alabel-domisili">
-								<strong id="alabel-domisili" class="requirement-item__title">Domisili</strong>
-								{location.requirementDetails.ktp}
-							</p>
-						{/if}
-						{#if location.requirementDetails.work}
-							<p class="requirement-item" aria-labelledby="alabel-kerja">
-								<strong id="alabel-kerja" class="requirement-item__title">Pekerjaan/Usaha</strong>
-								{location.requirementDetails.work}
-							</p>
-						{/if}
-						{#if location.requirementDetails.note}
-							<p class="requirement-item">
-								<strong class="requirement-item__title hide-if-only">Lainnya</strong>
-								{location.requirementDetails.note}
-							</p>
-						{/if}
-					</div>
-				</section>
-			{/if}
+		{#if location.canRegister && Object.keys(location.requirementDetails).length}
+			<LocDetailSection title="Syarat">
+				<div class="cv-loc-page__list-container">
+					<RequirementList data={location.requirementDetails} />
+				</div>
+			</LocDetailSection>
+		{/if}
 
-			{#if location.canRegister && location.registrations?.length}
-				<section class="top-section" aria-labelledby="alabel-pendaftaran">
-					<h2 id="alabel-pendaftaran">Pendaftaran</h2>
-					<div class="grid gap-3 text-sm">
-						{#if location.registrations.includes("Daftar di lokasi")}
-							<p>{location.registrations.join(", ")}</p>
-						{/if}
-						{#if location.registerLinks.app}
-							<section class="list-no-cta" aria-label="aplikasi">
-								<span>📱</span>
-								<p>
-									Daftar melalui aplikasi. Unduh di
-									{#each location.registerLinks.app as appLink, i}
-										<a class="cv-inline-link" href={appLink.url}>{appLink.text}</a
-										>{#if i < 1 && location.registerLinks.app.length > 1}&nbsp;/&nbsp;{/if}
-									{/each}
-								</p>
-							</section>
-						{/if}
-						{#if location.registerLinks.form}
-							<section class="list-with-cta" aria-label="formulir">
-								<span>📱</span>
-								<p>{location.registerLinks.form.replace("https://", "").replace("http://", "")}</p>
-								<a class="list__item-cta cv-mini-btn" href={location.registerLinks.form}>Buka</a>
-							</section>
-						{/if}
-						{#if location.registerLinks.phone}
-							<section class="list-with-cta" aria-label="telepon">
-								<span>📞</span>
-								<p>{location.registerLinks.phone.text}</p>
-								<a class="list__item-cta" href={location.registerLinks.phone.url}>Panggil</a>
-							</section>
-						{/if}
-						{#if location.registerLinks.whatsapp}
-							<section class="list-with-cta" aria-label="whatsapp">
-								<span class="pt-0.5">
-									<!-- prettier-ignore -->
-									<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 58 58">
-										<path style="fill:#2CB742;" d="M0,58l4.988-14.963C2.457,38.78,1,33.812,1,28.5C1,12.76,13.76,0,29.5,0S58,12.76,58,28.5
-											S45.24,57,29.5,57c-4.789,0-9.299-1.187-13.26-3.273L0,58z"/>
-										<path style="fill:#FFFFFF;" d="M47.683,37.985c-1.316-2.487-6.169-5.331-6.169-5.331c-1.098-0.626-2.423-0.696-3.049,0.42
-											c0,0-1.577,1.891-1.978,2.163c-1.832,1.241-3.529,1.193-5.242-0.52l-3.981-3.981l-3.981-3.981c-1.713-1.713-1.761-3.41-0.52-5.242
-											c0.272-0.401,2.163-1.978,2.163-1.978c1.116-0.627,1.046-1.951,0.42-3.049c0,0-2.844-4.853-5.331-6.169
-											c-1.058-0.56-2.357-0.364-3.203,0.482l-1.758,1.758c-5.577,5.577-2.831,11.873,2.746,17.45l5.097,5.097l5.097,5.097
-											c5.577,5.577,11.873,8.323,17.45,2.746l1.758-1.758C48.048,40.341,48.243,39.042,47.683,37.985z"/>
-									</svg>
-								</span>
-								<span>{location.registerLinks.whatsapp.text}</span>
-								<a class="list__item-cta" href={location.registerLinks.whatsapp.url}>Kirim</a>
-							</section>
-						{/if}
-						{#if location.registerNote}
-							<div class="text-gray-700 text-xs whitespace-pre-line max-w-xl mt-1">
-								{location.registerNote}
-							</div>
-						{/if}
-					</div>
-				</section>
-			{/if}
+		{#if location.canRegister && location.registrations?.length}
+			<LocDetailSection title="Pendaftaran">
+				<div class="cv-loc-page__list-container">
+					<RegistrationList
+						registrations={location.registrations}
+						registerLinks={location.registerLinks}
+						registerNote={location.registerNote}
+					/>
+				</div>
+			</LocDetailSection>
+		{/if}
 
-			{#if location.canRegister && (location.days || location.hours || location.dailyQuota)}
-				<section class="top-section" aria-labelledby="alabel-jadwal">
-					<h2 id="alabel-jadwal">Jadwal</h2>
-					<dl class="list-no-cta">
-						{#if location.days}
-							<dt aria-label="hari">🗓</dt>
-							<dd>{`Setiap hari ${location.days}`}</dd>
-						{/if}
-						{#if location.hours}
-							<dt aria-label="jam">🕐</dt>
-							<dd>{`Pukul ${location.hours}`}</dd>
-						{/if}
-						{#if location.dailyQuota}
-							<dt aria-label="kuota">👥</dt>
-							<dd>{`Kuota ${location.dailyQuota} orang/hari`}</dd>
-						{/if}
-					</dl>
-				</section>
-			{/if}
+		{#if location.canRegister && (location.days || location.hours || location.dailyQuota)}
+			<LocDetailSection title="Jadwal">
+				<dl class="cv-list-no-cta text-sm">
+					{#if location.days}
+						<dt aria-label="hari">🗓</dt>
+						<dd>{`Setiap hari ${location.days}`}</dd>
+					{/if}
+					{#if location.hours}
+						<dt aria-label="jam">🕐</dt>
+						<dd>{`Pukul ${location.hours}`}</dd>
+					{/if}
+					{#if location.dailyQuota}
+						<dt aria-label="kuota">👥</dt>
+						<dd>{`Kuota ${location.dailyQuota} orang/hari`}</dd>
+					{/if}
+				</dl>
+			</LocDetailSection>
+		{/if}
 
-			{#if location.gmapUrl || location.address || location.phone}
-				<section class="top-section" aria-labelledby="alabel-alamat">
-					<h2 id="alabel-alamat">Alamat &amp; Kontak</h2>
+		{#if location.gmapUrl || location.address || location.phone}
+			<LocDetailSection title="Alamat & Kontak">
+				<div class="cv-loc-page__list-container">
 					{#if location.gmapUrl || location.address}
-						<section class="list-with-cta py-2" aria-label="alamat">
-							<span>
-								<!-- prettier-ignore -->
-								<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" class="text-indigo-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-									<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z" />
-									<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 11a3 3 0 11-6 0 3 3 0 016 0z" />
-								 </svg>
-							</span>
-							<span>
-								{location.address || `${location.city}, ${PROVINCE_NAME}`}
-							</span>
-							<a class="list__item-cta" href={location.gmapUrl} rel="external">Maps</a>
-						</section>
+						<ListItemWithCta
+							aria-label="alamat"
+							text={location.address || `${location.city}, ${PROVINCE_NAME}`}
+							cta={{ href: location.gmapUrl, text: "Maps" }}
+						>
+							<!-- prettier-ignore -->
+							<svg slot="icon" xmlns="http://www.w3.org/2000/svg" width="16" height="16" class="text-indigo-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+							<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z" />
+							<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 11a3 3 0 11-6 0 3 3 0 016 0z" />
+						</svg>
+						</ListItemWithCta>
 					{/if}
 					{#if location.phone}
-						<section class="list-with-cta py-2" aria-label="telepon">
+						<ListItemWithCta
+							aria-label="telepon"
+							text={location.phone.text}
+							cta={{ href: location.phone.url, text: "Panggil" }}
+						>
 							<!-- prettier-ignore -->
-							<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" class="text-indigo-500" viewBox="0 0 20 20" fill="currentColor">
-								<path d="M2 3a1 1 0 011-1h2.153a1 1 0 01.986.836l.74 4.435a1 1 0 01-.54 1.06l-1.548.773a11.037 11.037 0 006.105 6.105l.774-1.548a1 1 0 011.059-.54l4.435.74a1 1 0 01.836.986V17a1 1 0 01-1 1h-2C7.82 18 2 12.18 2 5V3z" />
-							</svg>
-							<span>{location.phone.text}</span>
-							<a class="list__item-cta" href={location.phone.url} rel="external">Panggil</a>
-						</section>
+							<svg slot="icon" xmlns="http://www.w3.org/2000/svg" width="16" height="16" class="text-indigo-500" viewBox="0 0 20 20" fill="currentColor">
+							<path d="M2 3a1 1 0 011-1h2.153a1 1 0 01.986.836l.74 4.435a1 1 0 01-.54 1.06l-1.548.773a11.037 11.037 0 006.105 6.105l.774-1.548a1 1 0 011.059-.54l4.435.74a1 1 0 01.836.986V17a1 1 0 01-1 1h-2C7.82 18 2 12.18 2 5V3z" />
+						</svg>
+						</ListItemWithCta>
 					{/if}
-				</section>
-			{/if}
+				</div>
+			</LocDetailSection>
+		{/if}
 
-			{#if location.source?.note}
-				<p class="text-xs text-gray-600 mt-2">{location.source.note}</p>
-			{/if}
-
-			{#if location.source?.url}
-				<section class="p-4" aria-label="sumber">
-					<p class="text-xs text-gray-600">
-						Sumber: <a class="cv-inline-link" href={location.source.url} rel="external">
-							{location.source.url.replace("https://", "")}
-						</a>
-					</p>
-					{#if shouldShowEmbedIg && location.source?.url.includes("instagram.com/p/")}
-						<div class="-mx-4 sm:mx-0 mt-4">
-							<EmbedInstagram url={location.source.url} />
-						</div>
-					{:else if shouldShowEmbedTwitter && location.source?.url.includes("twitter.com/")}
-						<div class="tweet-container pt-2 text-white flex justify-center">
-							<blockquote class="twitter-tweet" data-conversation="none">
-								<a href={location.source.url}>2021</a>
-							</blockquote>
-						</div>
-					{/if}
-				</section>
-			{/if}
-
-			{#if location.type && location.type == "Puskesmas"}
-				<PuskesmasList />
-			{/if}
-		</div>
+		{#if location.source?.url}
+			<section class="py-4" aria-label="sumber">
+				<p class="text-xs text-gray-700">
+					Sumber: <a class="cv-inline-link" href={location.source.url} rel="external">
+						{location.source.url.replace("https://", "")}
+					</a>
+				</p>
+				{#if location.source?.note}
+					<p class="text-xs text-gray-700 leading-normal mt-2 px-4 pb-4">{location.source.note}</p>
+				{/if}
+				{#if shouldShowEmbedIg && location.source?.url.includes("instagram.com/p/")}
+					<div class="-mx-4 sm:mx-0 mt-4">
+						<EmbedInstagram url={location.source.url} />
+					</div>
+				{:else if shouldShowEmbedTwitter && location.source?.url.includes("twitter.com/")}
+					<div class="tweet-container pt-2 text-white flex justify-center">
+						<blockquote class="twitter-tweet" data-conversation="none">
+							<a href={location.source.url}>2021</a>
+						</blockquote>
+					</div>
+				{/if}
+			</section>
+		{/if}
 	{:else}
 		<div role="alert" class="text-center py-16">
 			<strong class="cv-misc-page__title">404</strong>
@@ -249,46 +183,6 @@
 </main>
 
 <style lang="postcss">
-	.top-section {
-		@apply p-4 border-b;
-	}
-	.top-section h2 {
-		@apply font-semibold sm:text-lg mb-2;
-	}
-	.requirement-item {
-		@apply whitespace-pre-line;
-	}
-	.requirement-item__title {
-		@apply text-indigo-600 font-semibold;
-	}
-	.requirement-item__title::after {
-		content: " · ";
-	}
-	.requirement-item:only-child .requirement-item__title.hide-if-only {
-		@apply sr-only;
-	}
-	.list-no-cta {
-		@apply grid gap-x-2 gap-y-3 text-sm;
-		grid-template-columns: 1rem 1fr;
-	}
-	.list-with-cta {
-		@apply grid gap-x-2 gap-y-2 text-sm relative items-start;
-		grid-template-columns: 1rem 1fr auto;
-	}
-	.list-with-cta > *:nth-child(3) {
-		margin-left: 0.25rem;
-	}
-	.list__item-cta {
-		@apply -mt-px w-16;
-	}
-	.list__item-cta::after {
-		content: "";
-		position: absolute;
-		top: 0;
-		bottom: 0;
-		left: 0;
-		right: 0;
-	}
 	.tweet-container {
 		min-height: 13rem;
 	}

--- a/src/routes/di/[slug].svelte
+++ b/src/routes/di/[slug].svelte
@@ -115,7 +115,7 @@
 							<section class="list-with-cta" aria-label="formulir">
 								<span>📱</span>
 								<p>{location.registerLinks.form.replace("https://", "").replace("http://", "")}</p>
-								<a class="list__item-cta" href={location.registerLinks.form}>Buka</a>
+								<a class="list__item-cta cv-mini-btn" href={location.registerLinks.form}>Buka</a>
 							</section>
 						{/if}
 						{#if location.registerLinks.phone}
@@ -279,7 +279,7 @@
 		margin-left: 0.25rem;
 	}
 	.list__item-cta {
-		@apply -mt-px py-0.5 px-2 text-center text-indigo-700 border border-indigo-700 hover:bg-indigo-700 focus:bg-indigo-700 hover:text-white focus:text-white rounded text-xs font-medium w-16;
+		@apply -mt-px w-16;
 	}
 	.list__item-cta::after {
 		content: "";

--- a/src/routes/p/[slug].svelte
+++ b/src/routes/p/[slug].svelte
@@ -1,0 +1,86 @@
+<script lang="ts" context="module">
+	import type { Load } from "@sveltejs/kit";
+
+	export const load: Load = async ({ page, fetch, session, context }) => {
+		const slug = page.params.slug;
+
+		let location;
+
+		return fetch(`/api/pd_location_${slug}`)
+			.then((res) => res.json())
+			.then((locationData) => {
+				location = locationData.payload;
+				return locationData.payload.city;
+			})
+			.then((city) => fetch(`/api/pd_clinics?city=${city}`))
+			.then((res) => res.json())
+			.then((clinicsData) => ({
+				props: {
+					location,
+					clinics: clinicsData.payload,
+				},
+			}))
+			.catch((err) => {
+				console.error(err);
+				return {
+					status: err.status,
+					error: new Error("Gagal memuat data lokasi/puskesmas"),
+				};
+			});
+	};
+</script>
+
+<script lang="ts">
+	import { onMount } from "svelte";
+	import {
+		LocDetailSection,
+		TagList,
+		RequirementList,
+		RegistrationList,
+		PuskesmasList,
+	} from "../../components";
+	import { HEADING_TEXT } from "$lib/constants";
+
+	export let location: ILocationFull;
+	export let clinics: IClinic[];
+</script>
+
+<svelte:head>
+	{#if location}<title>{location.name} — {HEADING_TEXT.title}</title>{/if}
+	<!-- <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script> -->
+</svelte:head>
+
+<main class="cv-page-outer">
+	{#if location}
+		<h1 class="cv-loc-page__title">{location.name}</h1>
+		<div class="mb-2" aria-label="kelompok usia">
+			<TagList requirements={location.requirementsByAgeGroup} />
+		</div>
+
+		{#if location.canRegister && Object.keys(location.requirementDetails).length}
+			<LocDetailSection title="Syarat">
+				<div class="cv-loc-page__list-container">
+					<RequirementList data={location.requirementDetails} />
+				</div>
+			</LocDetailSection>
+		{/if}
+
+		{#if location.canRegister && location.registrations?.length}
+			<LocDetailSection title="Pendaftaran">
+				<div class="cv-loc-page__list-container">
+					<RegistrationList
+						registrations={location.registrations}
+						registerLinks={location.registerLinks}
+						registerNote={location.registerNote}
+					/>
+				</div>
+			</LocDetailSection>
+		{/if}
+
+		{#if clinics}
+			<LocDetailSection title="Daftar Puskesmas">
+				<PuskesmasList {clinics} />
+			</LocDetailSection>
+		{/if}
+	{/if}
+</main>

--- a/src/service-worker.ts
+++ b/src/service-worker.ts
@@ -60,6 +60,7 @@ registerRoute(
 		url.pathname == START_URL ||
 		url.pathname.startsWith("/api/") ||
 		url.pathname.startsWith("/di/") ||
+		url.pathname.startsWith("/p/") ||
 		request.destination == "document",
 	new StaleWhileRevalidate({
 		cacheName: "cv-routes",


### PR DESCRIPTION
- add new route `/p/[slug]` for Puskesmas entries
- refactor UI components and styles so they can be consumed by both regular entries and Puskesmas entries

about Puskesmas entries
- one entry (route) for a city, eg. "Puskesmas di Sleman"
   - rationale: all puskesmas in a region (kota/kab.) adhere to respective local regulations
- a Puskesmas is stored as a row in a regular location table, thus it can & does have fields for requirements, registration etc like regular locations. I omit irrelevant parts like address and source.
- a Puskesmas differs from a regular location in that it fetches list of puskesmas name & address from a separate table through the `pd_clinics` route and displays them. This could be tidied up / refactored later.