### PR TITLE
Prerender static routes

### DIFF
--- a/src/components/Header.svelte
+++ b/src/components/Header.svelte
@@ -11,7 +11,9 @@
 		<button>dark</button>
 	</nav> -->
 		<h1 class="font-bold text-4xl md:text-5xl">
-			<a class="home-header-link text-indigo-600" href="/">{HEADING_TEXT.title}</a>
+			<a href="/" class="home-header-link text-indigo-600">
+				{HEADING_TEXT.title}
+			</a>
 			<small class="block mt-2 font-medium text-lg sm:text-xl leading-tight text-gray-500">
 				{HEADING_TEXT.subtitle}
 			</small>
@@ -20,8 +22,8 @@
 {:else if mode == "COMPACT"}
 	<header class="cv-page-outer mt-4 sm:mt-6 mb-2">
 		<a
-			class="text-sm text-indigo-600 font-semibold border-b hover:border-gray-400"
 			href="/"
+			class="text-sm text-indigo-600 font-semibold border-b hover:border-gray-400"
 			aria-label={`Beranda - ${HEADING_TEXT.title}`}
 		>
 			&larr; {HEADING_TEXT.title}

--- a/src/components/LocDetailSection.svelte
+++ b/src/components/LocDetailSection.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import slugify from "slugify";
-	import { SLUGIFY_OPTIONS } from "$lib/constants";
+	import { SLUGIFY_OPTIONS } from "$lib/slug";
 
 	export let title: string;
 

--- a/src/components/LocationList.svelte
+++ b/src/components/LocationList.svelte
@@ -1,14 +1,8 @@
 <script lang="ts">
-	import slugify from "slugify";
-	import { SLUGIFY_OPTIONS } from "$lib/constants";
+	import { makeSlug } from "$lib/slug";
 	import TagList from "./TagList.svelte";
 
 	export let locations: ILocationInList[] = [];
-
-	const makeSlug = (name: string, type: string = null) => {
-		const path = type && type.toLowerCase() == "puskesmas" ? "p" : "di";
-		return `/${path}/${slugify(name, SLUGIFY_OPTIONS)}`;
-	};
 
 	// $: console.log("loc length?", locations);
 </script>
@@ -19,9 +13,9 @@
 		aria-labelledby={`alabel-${loc.id}`}
 	>
 		<a
-			id={`alabel-${loc.id}`}
-			class={`location__name ${loc.type ? `location__name--${loc.type.toLowerCase()}` : ""}`}
 			href={makeSlug(loc.name, loc.type)}
+			class={`location__name ${loc.type ? `location__name--${loc.type.toLowerCase()}` : ""}`}
+			id={`alabel-${loc.id}`}
 			sveltekit:prefetch
 		>
 			{`${loc.name} ${loc.canRegister ? "" : " ⛔️"}`}

--- a/src/components/LocationList.svelte
+++ b/src/components/LocationList.svelte
@@ -4,7 +4,27 @@
 
 	export let locations: ILocationInList[] = [];
 
-	// $: console.log("loc length?", locations);
+	// = = = = =
+
+	// Re-enable if needed + does not break SW caching
+
+	// import { onMount } from "svelte";
+	// import { prefetch } from "$app/navigation";
+	// import { userSettings } from "$lib/stores";
+
+	// Running prefetch outside onMount/without timeout fails due to this issue: https://github.com/sveltejs/kit/issues/1605
+	// prefetchRoutes does not work(?).
+	// onMount(() => {
+	// 	let urls = ["/", ...locations.map((loc) => makeSlug(loc.name, loc.type))];
+	// 	setTimeout(() => {
+	// 		Promise.all(urls.map((url) => prefetch(url)))
+	// 			.then((responses) => {
+	// 				console.log("prefetched???", responses);
+	// 				$userSettings.hasPrefetched = true;
+	// 			})
+	// 			.catch((err) => { console.error(err) }); // prettier-ignore
+	// 	}, 200);
+	// });
 </script>
 
 {#each locations as loc}

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -29,11 +29,6 @@ export const OPTION_REGISTRATIONS: RegistrationOption[] = [
 	"Daftar online atau telepon",
 ];
 
-export const SLUGIFY_OPTIONS = {
-	lower: true,
-	strict: true,
-};
-
 export const INITIAL_LOC_FILTERS: ILocFilter = {
 	AGE: null,
 	CITY: null,

--- a/src/lib/slug.ts
+++ b/src/lib/slug.ts
@@ -1,0 +1,12 @@
+/* eslint-disable @typescript-eslint/explicit-module-boundary-types */
+import slugify from "slugify";
+
+export const SLUGIFY_OPTIONS = {
+	lower: true,
+	strict: true,
+};
+
+export const makeSlug = (name: string, type: string = null) => {
+	const path = type && type.toLowerCase() == "puskesmas" ? "p" : "di";
+	return `/${path}/${slugify(name, SLUGIFY_OPTIONS)}`;
+};

--- a/src/routes/__layout.svelte
+++ b/src/routes/__layout.svelte
@@ -22,13 +22,14 @@
 			// not used right now, leave for future stuff eg. push notif
 			let registration: ServiceWorkerRegistration | null;
 
-			wb.addEventListener("activated", (event) => {
+			wb.addEventListener("activated", async (event) => {
 				console.log("~~~ ✨ WB activated ~~~", event.isUpdate ? "" : "🐥 first time");
 				// see: https://developers.google.com/web/tools/workbox/modules/workbox-window#example-first-active
 				if (!event.isUpdate) offlineReady = true;
 			});
 
 			// Leave for debugging.
+			// see: https://developers.google.com/web/tools/workbox/modules/workbox-window#the_very_first_time_a_service_worker_is_installed
 			const WB_EVENTS = ["installing", "installed", "waiting", "activating", "controlling", "redundant"]; // prettier-ignore
 			WB_EVENTS.forEach((wbEvent) => {
 				wb.addEventListener(wbEvent as keyof WorkboxLifecycleEventMap, (event) => {

--- a/src/routes/api/pd_location_[slug].ts
+++ b/src/routes/api/pd_location_[slug].ts
@@ -11,6 +11,18 @@ const { PIPEDREAM_API_URL } = process.env; // must be destructured, else strippe
 export const get: RequestHandler = async ({ params }) => {
 	const { slug } = params;
 
+	//!!
+	return {
+		body: {
+			payload: {
+				id: slug,
+				name: "foo",
+				city: "Kota Yogyakarta",
+			},
+		},
+	};
+	//!!
+
 	const url = `${PIPEDREAM_API_URL}?slug=${slug}`;
 	const res = await fetch(url);
 	if (res.ok) {

--- a/src/routes/api/pd_location_[slug].ts
+++ b/src/routes/api/pd_location_[slug].ts
@@ -11,18 +11,6 @@ const { PIPEDREAM_API_URL } = process.env; // must be destructured, else strippe
 export const get: RequestHandler = async ({ params }) => {
 	const { slug } = params;
 
-	//!!
-	return {
-		body: {
-			payload: {
-				id: slug,
-				name: "foo",
-				city: "Kota Yogyakarta",
-			},
-		},
-	};
-	//!!
-
 	const url = `${PIPEDREAM_API_URL}?slug=${slug}`;
 	const res = await fetch(url);
 	if (res.ok) {

--- a/src/routes/api/pd_locations.ts
+++ b/src/routes/api/pd_locations.ts
@@ -22,9 +22,9 @@ interface IMyOutput {
 
 export const get = async (): Promise<IMyOutput> => {
 	// if (dev)
-	return {
-		body: { payload: [] },
-	};
+	// return {
+	// 	body: { payload: [] },
+	// };
 
 	const res = await fetch(PIPEDREAM_API_URL);
 	if (res.ok) {

--- a/src/routes/api/pd_locations.ts
+++ b/src/routes/api/pd_locations.ts
@@ -22,9 +22,9 @@ interface IMyOutput {
 
 export const get = async (): Promise<IMyOutput> => {
 	// if (dev)
-	// 	return {
-	// 		body: { payload: [] },
-	// 	};
+	return {
+		body: { payload: [] },
+	};
 
 	const res = await fetch(PIPEDREAM_API_URL);
 	if (res.ok) {

--- a/src/routes/index.svelte
+++ b/src/routes/index.svelte
@@ -14,7 +14,7 @@
 			// Returning any object with no error prop = rendering the HTML shell without props data (ie. location).
 			status: res.status, // Default to 500 if not returned, but not seemed to be passed anywhere.
 
-			// Returning object with "error" prop = rendering adjacemt __error component.
+			// Returning object with "error" prop = rendering __error component from the closest dir level.
 			error: new Error(`${res.statusText || "Gagal memuat data"}`),
 		};
 	};

--- a/src/routes/index.svelte
+++ b/src/routes/index.svelte
@@ -26,13 +26,11 @@
 	import { useMachine } from "@xstate/svelte";
 	import { vaxMachineConfig, vaxMachineOptions, vaxModel } from "$lib/machines/vaxMachine";
 	import { OPTION_CITIES, OPTION_AGES } from "$lib/constants";
+	import { makeSlug } from "$lib/slug";
+	import { userSettings } from "$lib/stores";
 	import { LocationList } from "../components";
 	import FilterButton from "../components/FilterButton.svelte";
 	import { HEADING_TEXT } from "$lib/constants";
-
-	// import { onMount } from "svelte";
-	// import { prefetch, prefetchRoutes } from "$app/navigation";
-	// import { userSettings } from "$lib/stores";
 
 	export let locations: ILocationInList[] = [];
 
@@ -65,22 +63,17 @@
 		});
 	};
 
-	// TODO move to LocationList?
-	// onMount(async () => {
-	// 	prefetchRoutes(
-	// 		locations
-	// 			.map((loc) => [
-	// 				`/di/${slugify(loc.name, SLUGIFY_OPTIONS)}`,
-	// 				`/api/pd_location_${slugify(loc.name, SLUGIFY_OPTIONS)}`,
-	// 			])
-	// 			.flat()
-	// 	).then(() => {
-	// 		$userSettings.hasPrefetched = true;
-	// 	});
-	// 	// not sure if i should use `prefetch` for server-rendered routes and/or API routes?
-	// 	// also prefetch still has this issue: https://github.com/sveltejs/kit/issues/1605
-	// });
-
+	// TODO (low priority) figure out where to run this
+	// ?? should be in SW install event instead?
+	if (browser && typeof window == "object") {
+		let urls = ["/", ...locations.map((loc) => makeSlug(loc.name, loc.type))];
+		window.caches
+			.open("cv-routes")
+			.then((cache) => cache.addAll(urls))
+			.then(() => { $userSettings.hasPrefetched = true })
+			.catch((err) => { console.error(err) }); // prettier-ignore
+	}
+	////
 	// $: console.log("🍏", $state.value);
 </script>
 

--- a/src/service-worker.ts
+++ b/src/service-worker.ts
@@ -13,6 +13,13 @@ const OFFLINE_URL = `/offline`;
 
 declare let self: ServiceWorkerGlobalScope;
 
+self.addEventListener("install", (event) => {
+	console.log("!!! SW install !!!");
+	// Activate new service worker as soon as it's finished installing.
+	// see: https://developers.google.com/web/fundamentals/primers/service-workers/lifecycle#skip_the_waiting_phase
+	event.waitUntil(self.skipWaiting());
+});
+
 self.addEventListener("activate", (event) => {
 	console.log("!!! SW activate !!!", event);
 	// the first time a service worker is installed it will active but not start controlling the page unless `clients.claim()` is called in the service worker.
@@ -20,11 +27,9 @@ self.addEventListener("activate", (event) => {
 	event.waitUntil(self.clients.claim());
 });
 
-self.addEventListener("install", (event) => {
-	console.log("!!! SW install !!!");
-	// Activate new service worker as soon as it's finished installing.
-	// see: https://developers.google.com/web/fundamentals/primers/service-workers/lifecycle#skip_the_waiting_phase
-	event.waitUntil(self.skipWaiting());
+self.addEventListener("message", (event) => {
+	console.log("!!! SW message !!!", event.data);
+	// if (event.data && event.data.type === "SKIP_WAITING") self.skipWaiting();
 });
 
 // ==============

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -1,34 +1,6 @@
 import preprocess from "svelte-preprocess";
 import adapterStatic from "@sveltejs/adapter-static";
 
-// define static paths manually 😭
-// also see: https://reecemay.me/articles/tip_sveltekit_static_pages_with_prismic/
-const prerenderPages = [
-	"/di/hi-lab",
-	"/di/poltekkes-kemenkes-yogyakarta",
-	"/di/rs-bethesda-lempuyangwangi",
-	"/di/rs-bethesda",
-	"/di/rs-dkt-dr-soetarto",
-	"/di/rs-happy-land",
-	"/di/rs-ludira-husada-tama",
-	"/di/rs-nur-hidayah",
-	"/di/rs-panti-nugroho",
-	"/di/rs-panti-rapih",
-	"/di/rs-panti-rini",
-	"/di/rs-pku-muhammadiyah-gamping",
-	"/di/rs-pku-muhammadiyah-yogyakarta",
-	"/di/rs-pratama",
-	"/di/rs-sakina-idaman",
-	"/di/rs-siloam",
-	"/di/rs-uad",
-	"/di/rsa-ugm",
-	"/di/rskia-arvita-bunda",
-	"/di/rskia-pku-muhammadiyah-kotagede",
-	"/di/rsup-dr-sardjito",
-	"/di/sentra-vaksinasi-kabupaten-bantul",
-];
-// const prerenderPages = [];
-
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
 	preprocess: preprocess({
@@ -37,12 +9,6 @@ const config = {
 	kit: {
 		adapter: adapterStatic(),
 		target: "#svelte",
-		prerender: {
-			crawl: true,
-			enabled: true,
-			force: false,
-			pages: ["*", ...prerenderPages],
-		},
 	},
 };
 


### PR DESCRIPTION
- Render locations content to static/SSG build
- Enable SvelteKit prerendering (no more hardcoded routes YAY!!!)

fun(?) fact:
SvelteKit automatically detects and prerenders dynamic routes statically, _but only if_ `href` is the first attribute.

This works:
```svelte
<a href={`/di/${location.slug}`} class="text-blue-400">{location.name}</a>
```

This does NOT work:
```svelte
<a class="text-blue-400" href={`/di/${location.slug}`}>{location.name}</a>
```